### PR TITLE
[14.0][IMP] project_task_calendar_advanced: support for task intervals

### DIFF
--- a/project_task_calendar_advanced/README.rst
+++ b/project_task_calendar_advanced/README.rst
@@ -22,10 +22,22 @@ Project Task - Calendar Advanced
 Adds a new menu with an advanced calendar that enables to manage tasks and
 users.
 
+This is achieved adding the *tasks intervals*, that enables see the same task
+available in the calendar. These intervals have a start date and a duration.
+
+Additionaly, a customer/internal task filter is available.
+
 **Table of contents**
 
 .. contents::
    :local:
+
+Known issues / Roadmap
+======================
+
+- Better place for Task Calendar in Project menu.
+- In Task ``tree`` view, show tags with tasks intervals.
+- Allowed users by interval?
 
 Bug Tracker
 ===========

--- a/project_task_calendar_advanced/__manifest__.py
+++ b/project_task_calendar_advanced/__manifest__.py
@@ -8,13 +8,14 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "14.0.1.0.0",
+    "version": "14.0.2.0.0",
     "category": "Project",
     "website": "https://github.com/solvosci/slv-project",
     "depends": ["project"],
     "data": [
         "security/ir.model.access.csv",
         "views/project_task_views.xml",
+        "views/project_task_interval_views.xml",
     ],
     'installable': True,
 }

--- a/project_task_calendar_advanced/i18n/es.po
+++ b/project_task_calendar_advanced/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-09 16:23+0000\n"
-"PO-Revision-Date: 2023-03-09 16:23+0000\n"
+"POT-Creation-Date: 2023-03-24 10:00+0000\n"
+"PO-Revision-Date: 2023-03-24 10:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: project_task_calendar_advanced
-#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task__date_planned_duration
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__date_planned_duration
 msgid ""
 "\n"
 "        For Task Calendar, indicates planned duration for this task\n"
@@ -27,7 +27,7 @@ msgstr ""
 "        "
 
 #. module: project_task_calendar_advanced
-#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task__date_planned_start
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__date_planned_start
 msgid ""
 "\n"
 "        For Task Calendar, indicates planned start date for this task\n"
@@ -39,6 +39,7 @@ msgstr ""
 
 #. module: project_task_calendar_advanced
 #: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task__partner_type
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__partner_type
 msgid ""
 "\n"
 "        Indicates task type according to associated partner:\n"
@@ -54,6 +55,7 @@ msgstr ""
 
 #. module: project_task_calendar_advanced
 #: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task__partner_type_color_id
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__partner_type_color_id
 msgid ""
 "\n"
 "        Technical field that help us to set a different color for tasks\n"
@@ -67,16 +69,62 @@ msgid "A user cannot have the same allowed user twice."
 msgstr "Un usuario no puede tener el mismo usuario permitido dos veces."
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__access_warning
+msgid "Access warning"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__active
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__active
 msgid "Active"
 msgstr "Activo"
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__analytic_account_active
+msgid "Active Analytic Account"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_ids
+msgid "Activities"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_state
+msgid "Activity State"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: model:ir.actions.act_window,name:project_task_calendar_advanced.action_view_task_advanced
 #: model:ir.ui.menu,name:project_task_calendar_advanced.menu_project_report_task_calendar_advanced
-#: model_terms:ir.ui.view,arch_db:project_task_calendar_advanced.view_task_calendar_advanced
+#: model_terms:ir.ui.view,arch_db:project_task_calendar_advanced.view_task_interval_calendar
 msgid "Advanced Task View"
 msgstr "Vista avanzada de tareas"
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__allow_subtasks
+msgid "Allow Sub-tasks"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__allow_timesheets
+msgid "Allow timesheets"
+msgstr ""
 
 #. module: project_task_calendar_advanced
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__allowed_user_id
@@ -84,35 +132,212 @@ msgid "Allowed User"
 msgstr "Usuario permitido"
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__user_id
+msgid "Assigned to"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__date_assign
+msgid "Assigning Date"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__attachment_ids
+msgid "Attachment that don't come from message."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__partner_is_company
+msgid "Check if the contact is a company, otherwise it is a person"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_city
+msgid "City"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__is_closed
+msgid "Closing Stage"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__color
+msgid "Color Index"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__commercial_partner_id
+msgid "Commercial Entity"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__company_id
+msgid "Company"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__displayed_image_id
+msgid "Cover Image"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__create_uid
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__create_uid
 msgid "Created by"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__create_date
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__create_date
 msgid "Created on"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_id
 #: model:ir.model.fields.selection,name:project_task_calendar_advanced.selection__project_task__partner_type__customer
 msgid "Customer"
 msgstr "Cliente"
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__access_url
+msgid "Customer Portal URL"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_weekday
+msgid "Day Of The Week"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__date_deadline
+msgid "Deadline"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__description
+msgid "Description"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__display_name
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__display_name
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__display_name
 msgid "Display Name"
 msgstr "Nombre mostrado"
 
 #. module: project_task_calendar_advanced
-#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__date_planned_duration
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__progress
+msgid "Display progress of current task."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__date_planned_duration
 msgid "Duration (h)"
 msgstr "Duración (h)"
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_email
+msgid "Email"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__email_from
+msgid "Email From"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__email_cc
+msgid "Email cc"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__encode_uom_in_days
+msgid "Encode Uom In Days"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_until
+msgid "End Date"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__date_end
+msgid "Ending Date"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_channel_ids
+msgid "Followers (Channels)"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__fri
+msgid "Fri"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__sequence
+msgid "Gives the sequence order when displaying a list of tasks."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__effective_hours
+msgid "Hours Spent"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__id
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__id
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__id
 msgid "ID"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_exception_icon
+msgid "Icon"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_needaction
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_unread
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_has_error
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__planned_hours
+msgid "Initially Planned Hours"
 msgstr ""
 
 #. module: project_task_calendar_advanced
@@ -121,19 +346,89 @@ msgid "Internal"
 msgstr "Interno"
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__task_interval_count
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__task_interval_count
+msgid "Interval count"
+msgstr "Nº de intervalos"
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__task_interval_ids
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__task_interval_ids
+msgid "Intervals"
+msgstr "Intervalos"
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_is_company
+msgid "Is a Company"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__legend_blocked
+msgid "Kanban Blocked Explanation"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__legend_normal
+msgid "Kanban Ongoing Explanation"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__kanban_state
+msgid "Kanban State"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__kanban_state_label
+msgid "Kanban State Label"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__legend_done
+msgid "Kanban Valid Explanation"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task____last_update
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval____last_update
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user____last_update
 msgid "Last Modified on"
 msgstr "Última modificación el"
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__date_last_stage_update
+msgid "Last Stage Update"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__write_uid
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__write_uid
 msgid "Last Updated by"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__write_date
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__write_date
 msgid "Last Updated on"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__email_cc
+msgid "List of cc from incoming emails."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_main_attachment_id
+msgid "Main Attachment"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__attachment_ids
+msgid "Main Attachments"
 msgstr ""
 
 #. module: project_task_calendar_advanced
@@ -142,22 +437,383 @@ msgid "Me"
 msgstr "Yo"
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__mon
+msgid "Mon"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_summary
+msgid "Next Activity Summary"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_type_id
+msgid "Next Activity Type"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__recurrence_message
+msgid "Next Recurrencies"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_needaction_counter
+msgid "Number of messages which requires an action"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_unread_counter
+msgid "Number of unread messages"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__legend_blocked
+msgid ""
+"Override the default value displayed for the blocked state for kanban "
+"selection, when the task or issue is in that stage."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__legend_done
+msgid ""
+"Override the default value displayed for the done state for kanban "
+"selection, when the task or issue is in that stage."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__legend_normal
+msgid ""
+"Override the default value displayed for the normal state for kanban "
+"selection, when the task or issue is in that stage."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__overtime
+msgid "Overtime"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__parent_id
+msgid "Parent Task"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__partner_type
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_type
 msgid "Partner Type"
 msgstr "Tipo de contacto"
 
 #. module: project_task_calendar_advanced
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__partner_type_color_id
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_type_color_id
 msgid "Partner Type Color"
 msgstr "Tipo de contacto para el color"
 
 #. module: project_task_calendar_advanced
-#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__date_planned_start
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__project_privacy_visibility
+msgid ""
+"People to whom this project and its tasks will be visible.\n"
+"\n"
+"- Invited internal users: when following a project, internal users will get access to all of its tasks without distinction. Otherwise, they will only get access to the specific tasks they are following.\n"
+" A user with the project > administrator access right level can still access this project and its tasks, even if they are not explicitly part of the followers.\n"
+"\n"
+"- All internal users: all internal users can access the project and all of its tasks without distinction.\n"
+"\n"
+"- Invited portal users and all internal users: all internal users can access the project and all of its tasks without distinction.\n"
+"When following a project, portal users will get access to all of its tasks without distinction. Otherwise, they will only get access to the specific tasks they are following."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_phone
+msgid "Phone"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__access_url
+msgid "Portal Access URL"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__priority
+msgid "Priority"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__progress
+msgid "Progress"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__project_id
+msgid "Project"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__manager_id
+msgid "Project Manager"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__project_privacy_visibility
+msgid "Project Visibility"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__subtask_project_id
+msgid ""
+"Project in which sub-tasks of the current project will be created. It can be"
+" the current project itself."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__rating_ids
+msgid "Rating"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__rating_avg
+msgid "Rating Average"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__rating_last_feedback
+msgid "Rating Last Feedback"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__rating_last_image
+msgid "Rating Last Image"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__rating_last_value
+msgid "Rating Last Value"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__rating_count
+msgid "Rating count"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__rating_last_feedback
+msgid "Reason of the rating"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__recurrence_id
+msgid "Recurrence"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__recurrence_update
+msgid "Recurrence Update"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__recurring_task
+msgid "Recurrent"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__allow_recurring_tasks
+msgid "Recurring Tasks"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__remaining_hours
+msgid "Remaining Hours"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_day
+msgid "Repeat Day"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_interval
+msgid "Repeat Every"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_month
+msgid "Repeat Month"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_on_month
+msgid "Repeat On Month"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_on_year
+msgid "Repeat On Year"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_show_day
+msgid "Repeat Show Day"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_show_dow
+msgid "Repeat Show Dow"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_show_month
+msgid "Repeat Show Month"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_show_week
+msgid "Repeat Show Week"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_unit
+msgid "Repeat Unit"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_week
+msgid "Repeat Week"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_number
+msgid "Repetitions"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_user_id
+msgid "Responsible User"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__ribbon_message
+msgid "Ribbon message"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__sat
+msgid "Sat"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__access_token
+msgid "Security Token"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__stage_id
+msgid "Stage"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__date_planned_start
 msgid "Start at"
 msgstr "Empieza en"
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__subtask_project_id
+msgid "Sub-task Project"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__subtask_count
+msgid "Sub-task count"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__child_ids
+msgid "Sub-tasks"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__subtask_effective_hours
+msgid "Sub-tasks Hours Spent"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__subtask_planned_hours
+msgid "Sub-tasks Planned Hours"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__subtask_planned_hours
+msgid ""
+"Sum of the time planned of all the sub-tasks linked to this task. Usually "
+"less or equal to the initially time planned of this task."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__sun
+msgid "Sun"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__tag_ids
+msgid "Tags"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: model:ir.model,name:project_task_calendar_advanced.model_project_task
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__task_id
 msgid "Task"
 msgstr "Tarea"
 
@@ -167,7 +823,165 @@ msgid "Task Calendar Allowed Users"
 msgstr "Usuarios permitidos del calendario de tareas"
 
 #. module: project_task_calendar_advanced
+#: model_terms:ir.ui.view,arch_db:project_task_calendar_advanced.view_task_interval_form
+msgid "Task Interval"
+msgstr "Intervalo de una tarea"
+
+#. module: project_task_calendar_advanced
+#: model:ir.model,name:project_task_calendar_advanced.model_project_task_interval
+msgid "Task Intervals"
+msgstr "Intervalos de la tarea"
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__recurring_count
+msgid "Tasks in Recurrence"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__is_closed
+msgid "Tasks in this stage are considered as closed."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__email_from
+msgid "These people will receive email."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__thu
+msgid "Thu"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__planned_hours
+msgid "Time planned to achieve this task (including its sub-tasks)."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__subtask_effective_hours
+msgid "Time spent on the sub-tasks (and their own sub-tasks) of this task."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__effective_hours
+msgid "Time spent on this task, excluding its sub-tasks."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__total_hours_spent
+msgid "Time spent on this task, including its sub-tasks."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__timesheet_ids
+msgid "Timesheets"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__allow_timesheets
+msgid "Timesheets can be logged on this task."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__name
+msgid "Title"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__total_hours_spent
+msgid "Total Hours"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__remaining_hours
+msgid ""
+"Total remaining time, can be re-estimated periodically by the assignee of "
+"the task."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__tue
+msgid "Tue"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_unread
+msgid "Unread Messages"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_unread_counter
+msgid "Unread Messages Counter"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_type
+msgid "Until"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__user_email
+msgid "User Email"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__allowed_user_ids
+msgid "Visible to"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__website_message_ids
+msgid "Website Messages"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__website_message_ids
+msgid "Website communication history"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__wed
+msgid "Wed"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model_terms:ir.ui.view,arch_db:project_task_calendar_advanced.view_task_search_form
+msgid "Without intervals"
+msgstr "Sin intervalos"
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__working_days_open
+msgid "Working days to assign"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__working_days_close
+msgid "Working days to close"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__working_hours_open
+msgid "Working hours to assign"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__working_hours_close
+msgid "Working hours to close"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: code:addons/project_task_calendar_advanced/models/project_task.py:0
 #, python-format
 msgid "You should set a duration for the following tasks: %s"
 msgstr "Debería asignar una duración para las siguientes tareas: %s"
+
+#. module: project_task_calendar_advanced
+#: code:addons/project_task_calendar_advanced/models/project_task_interval.py:0
+#, python-format
+msgid "You should set a valid duration for the following tasks: %s"
+msgstr "Debería establecer una duración válida para las siguientes tareas: %s"

--- a/project_task_calendar_advanced/i18n/project_task_calendar_advanced.pot
+++ b/project_task_calendar_advanced/i18n/project_task_calendar_advanced.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-09 16:22+0000\n"
-"PO-Revision-Date: 2023-03-09 16:22+0000\n"
+"POT-Creation-Date: 2023-03-24 10:00+0000\n"
+"PO-Revision-Date: 2023-03-24 10:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: project_task_calendar_advanced
-#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task__date_planned_duration
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__date_planned_duration
 msgid ""
 "\n"
 "        For Task Calendar, indicates planned duration for this task\n"
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 
 #. module: project_task_calendar_advanced
-#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task__date_planned_start
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__date_planned_start
 msgid ""
 "\n"
 "        For Task Calendar, indicates planned start date for this task\n"
@@ -33,6 +33,7 @@ msgstr ""
 
 #. module: project_task_calendar_advanced
 #: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task__partner_type
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__partner_type
 msgid ""
 "\n"
 "        Indicates task type according to associated partner:\n"
@@ -43,6 +44,7 @@ msgstr ""
 
 #. module: project_task_calendar_advanced
 #: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task__partner_type_color_id
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__partner_type_color_id
 msgid ""
 "\n"
 "        Technical field that help us to set a different color for tasks\n"
@@ -56,15 +58,61 @@ msgid "A user cannot have the same allowed user twice."
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__access_warning
+msgid "Access warning"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__active
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__active
 msgid "Active"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__analytic_account_active
+msgid "Active Analytic Account"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_ids
+msgid "Activities"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_state
+msgid "Activity State"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: model:ir.actions.act_window,name:project_task_calendar_advanced.action_view_task_advanced
 #: model:ir.ui.menu,name:project_task_calendar_advanced.menu_project_report_task_calendar_advanced
-#: model_terms:ir.ui.view,arch_db:project_task_calendar_advanced.view_task_calendar_advanced
+#: model_terms:ir.ui.view,arch_db:project_task_calendar_advanced.view_task_interval_calendar
 msgid "Advanced Task View"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__allow_subtasks
+msgid "Allow Sub-tasks"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__allow_timesheets
+msgid "Allow timesheets"
 msgstr ""
 
 #. module: project_task_calendar_advanced
@@ -73,35 +121,212 @@ msgid "Allowed User"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__user_id
+msgid "Assigned to"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__date_assign
+msgid "Assigning Date"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__attachment_ids
+msgid "Attachment that don't come from message."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__partner_is_company
+msgid "Check if the contact is a company, otherwise it is a person"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_city
+msgid "City"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__is_closed
+msgid "Closing Stage"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__color
+msgid "Color Index"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__commercial_partner_id
+msgid "Commercial Entity"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__company_id
+msgid "Company"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__displayed_image_id
+msgid "Cover Image"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__create_uid
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__create_uid
 msgid "Created by"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__create_date
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__create_date
 msgid "Created on"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_id
 #: model:ir.model.fields.selection,name:project_task_calendar_advanced.selection__project_task__partner_type__customer
 msgid "Customer"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__access_url
+msgid "Customer Portal URL"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_weekday
+msgid "Day Of The Week"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__date_deadline
+msgid "Deadline"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__description
+msgid "Description"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__display_name
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__display_name
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__display_name
 msgid "Display Name"
 msgstr ""
 
 #. module: project_task_calendar_advanced
-#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__date_planned_duration
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__progress
+msgid "Display progress of current task."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__date_planned_duration
 msgid "Duration (h)"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_email
+msgid "Email"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__email_from
+msgid "Email From"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__email_cc
+msgid "Email cc"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__encode_uom_in_days
+msgid "Encode Uom In Days"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_until
+msgid "End Date"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__date_end
+msgid "Ending Date"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_channel_ids
+msgid "Followers (Channels)"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__fri
+msgid "Fri"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__sequence
+msgid "Gives the sequence order when displaying a list of tasks."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__effective_hours
+msgid "Hours Spent"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__id
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__id
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__id
 msgid "ID"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_exception_icon
+msgid "Icon"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_needaction
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_unread
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_has_error
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__planned_hours
+msgid "Initially Planned Hours"
 msgstr ""
 
 #. module: project_task_calendar_advanced
@@ -110,19 +335,89 @@ msgid "Internal"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__task_interval_count
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__task_interval_count
+msgid "Interval count"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__task_interval_ids
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__task_interval_ids
+msgid "Intervals"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_is_company
+msgid "Is a Company"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__legend_blocked
+msgid "Kanban Blocked Explanation"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__legend_normal
+msgid "Kanban Ongoing Explanation"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__kanban_state
+msgid "Kanban State"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__kanban_state_label
+msgid "Kanban State Label"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__legend_done
+msgid "Kanban Valid Explanation"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task____last_update
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval____last_update
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user____last_update
 msgid "Last Modified on"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__date_last_stage_update
+msgid "Last Stage Update"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__write_uid
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__write_uid
 msgid "Last Updated by"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__write_date
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_user__write_date
 msgid "Last Updated on"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__email_cc
+msgid "List of cc from incoming emails."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_main_attachment_id
+msgid "Main Attachment"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__attachment_ids
+msgid "Main Attachments"
 msgstr ""
 
 #. module: project_task_calendar_advanced
@@ -131,22 +426,383 @@ msgid "Me"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__mon
+msgid "Mon"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_summary
+msgid "Next Activity Summary"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_type_id
+msgid "Next Activity Type"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__recurrence_message
+msgid "Next Recurrencies"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_needaction_counter
+msgid "Number of messages which requires an action"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__message_unread_counter
+msgid "Number of unread messages"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__legend_blocked
+msgid ""
+"Override the default value displayed for the blocked state for kanban "
+"selection, when the task or issue is in that stage."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__legend_done
+msgid ""
+"Override the default value displayed for the done state for kanban "
+"selection, when the task or issue is in that stage."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__legend_normal
+msgid ""
+"Override the default value displayed for the normal state for kanban "
+"selection, when the task or issue is in that stage."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__overtime
+msgid "Overtime"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__parent_id
+msgid "Parent Task"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__partner_type
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_type
 msgid "Partner Type"
 msgstr ""
 
 #. module: project_task_calendar_advanced
 #: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__partner_type_color_id
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_type_color_id
 msgid "Partner Type Color"
 msgstr ""
 
 #. module: project_task_calendar_advanced
-#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task__date_planned_start
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__project_privacy_visibility
+msgid ""
+"People to whom this project and its tasks will be visible.\n"
+"\n"
+"- Invited internal users: when following a project, internal users will get access to all of its tasks without distinction. Otherwise, they will only get access to the specific tasks they are following.\n"
+" A user with the project > administrator access right level can still access this project and its tasks, even if they are not explicitly part of the followers.\n"
+"\n"
+"- All internal users: all internal users can access the project and all of its tasks without distinction.\n"
+"\n"
+"- Invited portal users and all internal users: all internal users can access the project and all of its tasks without distinction.\n"
+"When following a project, portal users will get access to all of its tasks without distinction. Otherwise, they will only get access to the specific tasks they are following."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__partner_phone
+msgid "Phone"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__access_url
+msgid "Portal Access URL"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__priority
+msgid "Priority"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__progress
+msgid "Progress"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__project_id
+msgid "Project"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__manager_id
+msgid "Project Manager"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__project_privacy_visibility
+msgid "Project Visibility"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__subtask_project_id
+msgid ""
+"Project in which sub-tasks of the current project will be created. It can be"
+" the current project itself."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__rating_ids
+msgid "Rating"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__rating_avg
+msgid "Rating Average"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__rating_last_feedback
+msgid "Rating Last Feedback"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__rating_last_image
+msgid "Rating Last Image"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__rating_last_value
+msgid "Rating Last Value"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__rating_count
+msgid "Rating count"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__rating_last_feedback
+msgid "Reason of the rating"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__recurrence_id
+msgid "Recurrence"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__recurrence_update
+msgid "Recurrence Update"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__recurring_task
+msgid "Recurrent"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__allow_recurring_tasks
+msgid "Recurring Tasks"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__remaining_hours
+msgid "Remaining Hours"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_day
+msgid "Repeat Day"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_interval
+msgid "Repeat Every"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_month
+msgid "Repeat Month"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_on_month
+msgid "Repeat On Month"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_on_year
+msgid "Repeat On Year"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_show_day
+msgid "Repeat Show Day"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_show_dow
+msgid "Repeat Show Dow"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_show_month
+msgid "Repeat Show Month"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_show_week
+msgid "Repeat Show Week"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_unit
+msgid "Repeat Unit"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_week
+msgid "Repeat Week"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_number
+msgid "Repetitions"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__activity_user_id
+msgid "Responsible User"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__ribbon_message
+msgid "Ribbon message"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__sat
+msgid "Sat"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__access_token
+msgid "Security Token"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__stage_id
+msgid "Stage"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__date_planned_start
 msgid "Start at"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__subtask_project_id
+msgid "Sub-task Project"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__subtask_count
+msgid "Sub-task count"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__child_ids
+msgid "Sub-tasks"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__subtask_effective_hours
+msgid "Sub-tasks Hours Spent"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__subtask_planned_hours
+msgid "Sub-tasks Planned Hours"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__subtask_planned_hours
+msgid ""
+"Sum of the time planned of all the sub-tasks linked to this task. Usually "
+"less or equal to the initially time planned of this task."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__sun
+msgid "Sun"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__tag_ids
+msgid "Tags"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: model:ir.model,name:project_task_calendar_advanced.model_project_task
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__task_id
 msgid "Task"
 msgstr ""
 
@@ -156,7 +812,165 @@ msgid "Task Calendar Allowed Users"
 msgstr ""
 
 #. module: project_task_calendar_advanced
+#: model_terms:ir.ui.view,arch_db:project_task_calendar_advanced.view_task_interval_form
+msgid "Task Interval"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model,name:project_task_calendar_advanced.model_project_task_interval
+msgid "Task Intervals"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__recurring_count
+msgid "Tasks in Recurrence"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__is_closed
+msgid "Tasks in this stage are considered as closed."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__email_from
+msgid "These people will receive email."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__thu
+msgid "Thu"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__planned_hours
+msgid "Time planned to achieve this task (including its sub-tasks)."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__subtask_effective_hours
+msgid "Time spent on the sub-tasks (and their own sub-tasks) of this task."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__effective_hours
+msgid "Time spent on this task, excluding its sub-tasks."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__total_hours_spent
+msgid "Time spent on this task, including its sub-tasks."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__timesheet_ids
+msgid "Timesheets"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__allow_timesheets
+msgid "Timesheets can be logged on this task."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__name
+msgid "Title"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__total_hours_spent
+msgid "Total Hours"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__remaining_hours
+msgid ""
+"Total remaining time, can be re-estimated periodically by the assignee of "
+"the task."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__tue
+msgid "Tue"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_unread
+msgid "Unread Messages"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__message_unread_counter
+msgid "Unread Messages Counter"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__repeat_type
+msgid "Until"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__user_email
+msgid "User Email"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__allowed_user_ids
+msgid "Visible to"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__website_message_ids
+msgid "Website Messages"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,help:project_task_calendar_advanced.field_project_task_interval__website_message_ids
+msgid "Website communication history"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__wed
+msgid "Wed"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model_terms:ir.ui.view,arch_db:project_task_calendar_advanced.view_task_search_form
+msgid "Without intervals"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__working_days_open
+msgid "Working days to assign"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__working_days_close
+msgid "Working days to close"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__working_hours_open
+msgid "Working hours to assign"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: model:ir.model.fields,field_description:project_task_calendar_advanced.field_project_task_interval__working_hours_close
+msgid "Working hours to close"
+msgstr ""
+
+#. module: project_task_calendar_advanced
 #: code:addons/project_task_calendar_advanced/models/project_task.py:0
 #, python-format
 msgid "You should set a duration for the following tasks: %s"
+msgstr ""
+
+#. module: project_task_calendar_advanced
+#: code:addons/project_task_calendar_advanced/models/project_task_interval.py:0
+#, python-format
+msgid "You should set a valid duration for the following tasks: %s"
 msgstr ""

--- a/project_task_calendar_advanced/models/__init__.py
+++ b/project_task_calendar_advanced/models/__init__.py
@@ -1,2 +1,3 @@
 from . import project_task
 from . import project_task_user
+from . import project_task_interval

--- a/project_task_calendar_advanced/models/project_task_interval.py
+++ b/project_task_calendar_advanced/models/project_task_interval.py
@@ -1,0 +1,48 @@
+# © 2023 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ProjectTaskInterval(models.Model):
+    _name = "project.task.interval"
+    _description = "Task Intervals"
+    _inherits = {"project.task": "task_id"}
+
+    task_id = fields.Many2one(
+        comodel_name="project.task",
+        string="Task",
+        auto_join=True,
+        index=True,
+        ondelete="cascade",
+        required=True,
+    )
+
+    date_planned_start = fields.Datetime(
+        string="Start at",
+        required=True,
+        help="""
+        For Task Calendar, indicates planned start date for this task
+        """,
+    )
+    date_planned_duration = fields.Float(
+        string="Duration (h)",
+        required=True,
+        help="""
+        For Task Calendar, indicates planned duration for this task
+        """,
+    )
+
+    @api.constrains("date_planned_start", "date_planned_duration")
+    def _check_date_planned_values(self):
+        # TODO check intervals overlapping
+        err_tasks = self.filtered(
+            lambda x: x.date_planned_duration <= 0.0
+        )
+        if err_tasks:
+            raise ValidationError(
+                _("You should set a valid duration for the following tasks: %s")
+                %
+                ", ".join(err_tasks.mapped("name"))
+            )

--- a/project_task_calendar_advanced/readme/DESCRIPTION.rst
+++ b/project_task_calendar_advanced/readme/DESCRIPTION.rst
@@ -1,2 +1,7 @@
 Adds a new menu with an advanced calendar that enables to manage tasks and
 users.
+
+This is achieved adding the *tasks intervals*, that enables see the same task
+available in the calendar. These intervals have a start date and a duration.
+
+Additionaly, a customer/internal task filter is available.

--- a/project_task_calendar_advanced/readme/ROADMAP.rst
+++ b/project_task_calendar_advanced/readme/ROADMAP.rst
@@ -1,0 +1,3 @@
+- Better place for Task Calendar in Project menu.
+- In Task ``tree`` view, show tags with tasks intervals.
+- Allowed users by interval?

--- a/project_task_calendar_advanced/security/ir.model.access.csv
+++ b/project_task_calendar_advanced/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_project_task_user_all,access_project_task_user_all,model_project_task_user,project.group_project_user,1,1,1,1
 access_project_task_user,access_project_task_user,model_project_task_user,base.group_system,1,1,1,1
+access_project_task_interval_user,access_project_task_interval_user,model_project_task_interval,project.group_project_user,1,0,0,0
+access_project_task_interval_manager,access_project_task_interval_manager,model_project_task_interval,project.group_project_manager,1,1,1,1

--- a/project_task_calendar_advanced/static/description/index.html
+++ b/project_task_calendar_advanced/static/description/index.html
@@ -370,20 +370,32 @@ ul.auto-toc {
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/solvosci/slv-project/tree/14.0/project_task_calendar_advanced"><img alt="solvosci/slv-project" src="https://img.shields.io/badge/github-solvosci%2Fslv--project-lightgray.png?logo=github" /></a></p>
 <p>Adds a new menu with an advanced calendar that enables to manage tasks and
 users.</p>
+<p>This is achieved adding the <em>tasks intervals</em>, that enables see the same task
+available in the calendar. These intervals have a start date and a duration.</p>
+<p>Additionaly, a customer/internal task filter is available.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="id1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id5">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id1">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id1">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>Better place for Task Calendar in Project menu.</li>
+<li>In Task <tt class="docutils literal">tree</tt> view, show tags with tasks intervals.</li>
+<li>Allowed users by interval?</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/solvosci/slv-project/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -391,21 +403,21 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id2">Credits</a></h1>
+<h1><a class="toc-backref" href="#id3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id3">Authors</a></h2>
+<h2><a class="toc-backref" href="#id4">Authors</a></h2>
 <ul class="simple">
 <li>Solvos</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id4">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
 <ul class="simple">
 <li>David Alonso &lt;<a class="reference external" href="mailto:david.alonso&#64;solvos.es">david.alonso&#64;solvos.es</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id5">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
 <p>This module is part of the <a class="reference external" href="https://github.com/solvosci/slv-project/tree/14.0/project_task_calendar_advanced">solvosci/slv-project</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>

--- a/project_task_calendar_advanced/views/project_task_interval_views.xml
+++ b/project_task_calendar_advanced/views/project_task_interval_views.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_task_interval_form" model="ir.ui.view">
+        <field name="name">project.task.interval.form</field>
+        <field name="model">project.task.interval</field>
+        <field name="arch" type="xml">
+            <form string="Task Interval" create="0">
+                <sheet string="Task Interval">
+                    <field name="company_id" invisible="1"/>
+                    <field name="project_privacy_visibility" invisible="1"/>                    
+                    <group>
+                        <group>
+                            <field name="project_id"/>
+                            <field name="partner_id" widget="res_partner_many2one" class="o_task_customer_field"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                            <field name="user_id"/>
+                        </group>
+                        <group>
+                            <field
+                                name="allowed_user_ids"
+                                widget="many2many_tags_avatar"
+                                attrs="{'invisible': [('project_privacy_visibility', 'not in', ('followers', 'portal'))]}"
+                            />
+                            <field name="date_planned_start" />
+                            <field name="date_planned_duration" widget="float_time" />
+                        </group>
+                    </group>                    
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="view_task_interval_calendar" model="ir.ui.view">
+        <field name="name">project.task.interval.calendar</field>
+        <field name="model">project.task.interval</field>
+        <field eval="100" name="priority"/>
+        <field name="arch" type="xml">
+            <calendar
+                date_start="date_planned_start"
+                date_delay="date_planned_duration"
+                string="Advanced Task View"
+                mode="week"
+                color="partner_type_color_id"
+                event_limit="5"
+                hide_time="False"
+                quick_add="False"
+            >
+                <field name="user_id" avatar_field="image_128" filters="1"/>
+                <field
+                    name="allowed_user_ids"
+                    widget="many2many_tags_avatar"
+                    write_model="project.task.user"
+                    write_field="allowed_user_id"
+                    avatar_field="image_128"
+                />
+                <field name="project_id"/>
+                <field name="partner_type" filters="1"/>
+            </calendar>
+        </field>
+    </record>
+
+    <record id="action_view_task_advanced" model="ir.actions.act_window">
+        <field name="name">Advanced Task View</field>
+        <field name="res_model">project.task.interval</field>
+        <field name="view_mode">calendar</field>
+        <field
+            name="view_ids"
+            eval="[
+                (5, 0, 0),
+                (0, 0, {'view_mode': 'calendar', 'view_id': ref('view_task_interval_calendar')}),
+            ]"
+        />        
+    </record>
+    <menuitem id="menu_project_report_task_calendar_advanced"
+        name="Advanced Task View"
+        action="project_task_calendar_advanced.action_view_task_advanced"
+        parent="project.menu_project_report"
+        sequence="5"
+    />
+
+</odoo>

--- a/project_task_calendar_advanced/views/project_task_views.xml
+++ b/project_task_calendar_advanced/views/project_task_views.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+    <record id="view_task_search_form" model="ir.ui.view">
+        <field name="name">
+            project.task.search.form (in project_task_calendar_advanced)
+        </field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.view_task_search_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='my_tasks']" position="before">
+                <filter
+                    name="filter_without_intervals"
+                    string="Without intervals"
+                    domain="[('task_interval_count','=',0)]"
+                />
+                <separator />
+            </xpath>
+        </field>
+    </record>
+
     <record id="view_task_form2" model="ir.ui.view">
         <field name="name">
             project.task.form (in project_task_calendar_advanced)
@@ -8,15 +26,12 @@
         <field name="inherit_id" ref="project.view_task_form2" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='date_deadline']" position="before">
-                <field name="date_planned_start" readonly="1"/>
-                <field
-                    name="date_planned_duration"
-                    readonly="1"
-                    attrs="{
-                        'invisible': [('date_planned_start','=',False)],
-                    }"
-                    widget="float_time"
-                />
+                <field name="task_interval_ids" readonly="1">
+                    <tree editable="bottom">
+                        <field name="date_planned_start" />
+                        <field name="date_planned_duration" widget="float_time" />
+                    </tree>
+                </field>
             </xpath>
             <xpath expr="//field[@name='sequence']" position="after">
                 <field name="partner_type" groups="base.group_no_one"/>
@@ -34,77 +49,9 @@
             eval="[(4, ref('project.group_project_manager'))]"
         />
         <field name="arch" type="xml">
-            <field name="date_planned_start" position="attributes">
-                <attribute name="readonly">0</attribute>
-            </field>
-            <field name="date_planned_duration" position="attributes">
+            <field name="task_interval_ids" position="attributes">
                 <attribute name="readonly">0</attribute>
             </field>
         </field>
     </record>
-
-    <record id="view_task_tree2" model="ir.ui.view">
-        <field name="name">
-            project.task.tree (in project_task_calendar_advanced)
-        </field>
-        <field name="model">project.task</field>
-        <field name="inherit_id" ref="project.view_task_tree2" />
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='user_id']" position="after">
-                <field
-                    name="date_planned_start"
-                    optional="hide"
-                />
-            </xpath>
-        </field>
-    </record>
-
-    <record id="view_task_calendar_advanced" model="ir.ui.view">
-        <field name="name">project.task.calendar.advanced</field>
-        <field name="model">project.task</field>
-        <field eval="100" name="priority"/>
-        <field name="arch" type="xml">
-            <calendar
-                date_start="date_planned_start"
-                date_delay="date_planned_duration"
-                string="Advanced Task View"
-                mode="week"
-                color="partner_type_color_id"
-                event_limit="5"
-                hide_time="False"
-                quick_add="False"
-            >
-                <field name="user_id" avatar_field="image_128" filters="1"/>
-                <field
-                    name="allowed_user_ids"
-                    widget="many2many_tags_avatar"
-                    write_model="project.task.user"
-                    write_field="allowed_user_id"
-                    avatar_field="image_128"
-                />
-                <field name="project_id"/>
-                <field name="partner_type" filters="1"/>
-            </calendar>
-        </field>
-    </record>
-
-    <record id="action_view_task_advanced" model="ir.actions.act_window">
-        <field name="name">Advanced Task View</field>
-        <field name="res_model">project.task</field>
-        <field name="view_mode">calendar</field>
-        <field
-            name="view_ids"
-            eval="[
-                (5, 0, 0),
-                (0, 0, {'view_mode': 'calendar', 'view_id': ref('view_task_calendar_advanced')}),
-            ]"
-        />        
-    </record>
-    <menuitem id="menu_project_report_task_calendar_advanced"
-        name="Advanced Task View"
-        action="project_task_calendar_advanced.action_view_task_advanced"
-        parent="project.menu_project_report"
-        sequence="5"
-    />
-
 </odoo>


### PR DESCRIPTION
With this improvement, task calendar becomes "task interval" calendar.
Now, for every task can be defined one ore more task intervals, that are properly shown in Task Advanced Calendar.
Then a task planning could be splitted in more than a day.