### PR TITLE
[14.0][FIX] project_task_followers_mgmt: ensure project access to task users

### DIFF
--- a/project_task_followers_mgmt/__manifest__.py
+++ b/project_task_followers_mgmt/__manifest__.py
@@ -7,9 +7,12 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "category": "Project",
     "website": "https://github.com/solvosci/slv-project",
     "depends": ["project"],
-    "data": ["views/project_task_views.xml"],
+    "data": [
+        "security/project_project_security.xml",
+        "views/project_task_views.xml",
+    ],
 }

--- a/project_task_followers_mgmt/security/project_project_security.xml
+++ b/project_task_followers_mgmt/security/project_project_security.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record model="ir.rule" id="project_allowed_user_ids_rule">
+            <field name="name">Project: add users allowed in tasks</field>
+            <field name="model_id" ref="project.model_project_project"/>
+            <field name="domain_force">[
+                '&amp;',
+                    ('privacy_visibility', '=', 'followers'),
+                    ('task_ids.allowed_user_ids', 'in', user.ids),
+            ]</field>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        </record>    
+    </data>
+</odoo>


### PR DESCRIPTION
Before this fix, granting access to a user in a task of a "follower" project granted access to the task, but not to the project. This fix it.