### PR TITLE
[14.0][FIX] project_task_followers_mgmt_timesheet: missing timesheet approver rule for followers

### DIFF
--- a/project_task_followers_mgmt_timesheet/__manifest__.py
+++ b/project_task_followers_mgmt_timesheet/__manifest__.py
@@ -8,8 +8,9 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "category": "Project",
     "website": "https://github.com/solvosci/slv-project",
     "depends": ["project_task_followers_mgmt", "hr_timesheet"],
+    "data": ["security/hr_timesheet_security.xml"],
 }

--- a/project_task_followers_mgmt_timesheet/security/hr_timesheet_security.xml
+++ b/project_task_followers_mgmt_timesheet/security/hr_timesheet_security.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record model="ir.rule" id="timesheet_line_rule_approver_followers">
+            <field name="name">account.analytic.line.timesheet.approver followers</field>
+            <field name="model_id" ref="analytic.model_account_analytic_line"/>
+            <field name="domain_force">[
+                '&amp;',
+                    ('project_id.privacy_visibility', '=', 'followers'),
+                    '|',
+                         ('project_id.allowed_internal_user_ids', 'in', user.ids),
+                         ('task_id.allowed_user_ids', 'in', user.ids),
+            ]</field>
+            <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]"/>
+        </record>    
+    </data>
+</odoo>


### PR DESCRIPTION
Before this fix, a Timesheet Approver user cannot read/edit a timesheet for those projects that are made for followers as `project_task_followers_mgmt` addon does. This fix it.