### PR TITLE
[14.0][IMP] project_task_followers_mgmt_timesheet: user report

### DIFF
--- a/project_task_followers_mgmt_timesheet/README.rst
+++ b/project_task_followers_mgmt_timesheet/README.rst
@@ -23,6 +23,10 @@ Timesheet extension for ``project_task_followers_mgmt`` addon, that enables
 selecting a proyect in timesheets that matches this addon requirements (accessing
 followers project it user is allowed in at least one task).
 
+Also adds a task analysis report based on task allowed users and their timesheets.
+Each allowed user will have as task planned hours a proportional part depending
+on the count of allowed users.
+
 **Table of contents**
 
 .. contents::

--- a/project_task_followers_mgmt_timesheet/__manifest__.py
+++ b/project_task_followers_mgmt_timesheet/__manifest__.py
@@ -8,9 +8,14 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "14.0.1.0.1",
+    "version": "14.0.2.0.0",
     "category": "Project",
     "website": "https://github.com/solvosci/slv-project",
     "depends": ["project_task_followers_mgmt", "hr_timesheet"],
-    "data": ["security/hr_timesheet_security.xml"],
+    "data": [
+        "security/ir.model.access.csv",
+        "security/hr_timesheet_security.xml",
+        "views/project_task_views.xml",
+        "views/project_task_timesheet_summary_views.xml",
+    ],
 }

--- a/project_task_followers_mgmt_timesheet/i18n/es.po
+++ b/project_task_followers_mgmt_timesheet/i18n/es.po
@@ -1,0 +1,990 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* project_task_followers_mgmt_timesheet
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-04-14 11:20+0000\n"
+"PO-Revision-Date: 2023-04-14 11:20+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_type
+msgid ""
+"\n"
+"        Indicates task type according to associated partner:\n"
+"        internal - belongs to an internal project (has no partner)\n"
+"        customer - the project was linked to a partner\n"
+"        "
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_type_color_id
+msgid ""
+"\n"
+"        Technical field that help us to set a different color for tasks\n"
+"        depending on their partner_type.\n"
+"        "
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__access_warning
+msgid "Access warning"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__active
+msgid "Active"
+msgstr "Activo"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__analytic_account_active
+msgid "Active Analytic Account"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Active Tasks"
+msgstr "Tareas activas"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_ids
+msgid "Activities"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_state
+msgid "Activity State"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__allow_subtasks
+msgid "Allow Sub-tasks"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__allow_timesheets
+msgid "Allow timesheets"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model,name:project_task_followers_mgmt_timesheet.model_account_analytic_line
+msgid "Analytic Line"
+msgstr "Línea Analítica"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__user_id
+msgid "Assigned to"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__date_assign
+msgid "Assigning Date"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__attachment_ids
+msgid "Attachment that don't come from message."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_is_company
+msgid "Check if the contact is a company, otherwise it is a person"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_city
+msgid "City"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__is_closed
+msgid "Closing Stage"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__color
+msgid "Color Index"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__commercial_partner_id
+msgid "Commercial Entity"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__company_id
+msgid "Company"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__displayed_image_id
+msgid "Cover Image"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_id
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Customer"
+msgstr "Cliente"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__access_url
+msgid "Customer Portal URL"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Customer Tasks"
+msgstr "Tareas de cliente"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_weekday
+msgid "Day Of The Week"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__date_deadline
+msgid "Deadline"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__description
+msgid "Description"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_form2
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_pivot
+msgid "Deviation"
+msgstr "Desviación"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_account_analytic_line__display_name
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_project__display_name
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task__display_name
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__progress
+msgid "Display progress of current task."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_form2
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_pivot
+msgid "Done"
+msgstr "Hecho"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_email
+msgid "Email"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__email_from
+msgid "Email From"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__email_cc
+msgid "Email cc"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__encode_uom_in_days
+msgid "Encode Uom In Days"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_until
+msgid "End Date"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__date_end
+msgid "Ending Date"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_channel_ids
+msgid "Followers (Channels)"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__fri
+msgid "Fri"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__sequence
+msgid "Gives the sequence order when displaying a list of tasks."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Group By"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__hours_deviation
+msgid "Hours Deviation"
+msgstr "Horas desviadas"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__hours_effective
+msgid "Hours Effective"
+msgstr "Horas efectivas"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__hours_planned
+msgid "Hours Planned"
+msgstr "Horas planificadas"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__effective_hours
+msgid "Hours Spent"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_account_analytic_line__id
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_project__id
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task__id
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__id
+msgid "ID"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_exception_icon
+msgid "Icon"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_needaction
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_unread
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_has_error
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Inactive Tasks"
+msgstr "Tareas archivadas"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__planned_hours
+msgid "Initially Planned Hours"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Internal Tasks"
+msgstr "Tareas internas"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__task_interval_count
+msgid "Interval count"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__task_interval_ids
+msgid "Intervals"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_is_company
+msgid "Is a Company"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__legend_blocked
+msgid "Kanban Blocked Explanation"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__legend_normal
+msgid "Kanban Ongoing Explanation"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__kanban_state
+msgid "Kanban State"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__kanban_state_label
+msgid "Kanban State Label"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__legend_done
+msgid "Kanban Valid Explanation"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_account_analytic_line____last_update
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_project____last_update
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task____last_update
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary____last_update
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__date_last_stage_update
+msgid "Last Stage Update"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__email_cc
+msgid "List of cc from incoming emails."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_main_attachment_id
+msgid "Main Attachment"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__attachment_ids
+msgid "Main Attachments"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__mon
+msgid "Mon"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_summary
+msgid "Next Activity Summary"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_type_id
+msgid "Next Activity Type"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__recurrence_message
+msgid "Next Recurrencies"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_needaction_counter
+msgid "Number of messages which requires an action"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_unread_counter
+msgid "Number of unread messages"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__legend_blocked
+msgid ""
+"Override the default value displayed for the blocked state for kanban "
+"selection, when the task or issue is in that stage."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__legend_done
+msgid ""
+"Override the default value displayed for the done state for kanban "
+"selection, when the task or issue is in that stage."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__legend_normal
+msgid ""
+"Override the default value displayed for the normal state for kanban "
+"selection, when the task or issue is in that stage."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__overtime
+msgid "Overtime"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__parent_id
+msgid "Parent Task"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_type
+msgid "Partner Type"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_type_color_id
+msgid "Partner Type Color"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__project_privacy_visibility
+msgid ""
+"People to whom this project and its tasks will be visible.\n"
+"\n"
+"- Invited internal users: when following a project, internal users will get access to all of its tasks without distinction. Otherwise, they will only get access to the specific tasks they are following.\n"
+" A user with the project > administrator access right level can still access this project and its tasks, even if they are not explicitly part of the followers.\n"
+"\n"
+"- All internal users: all internal users can access the project and all of its tasks without distinction.\n"
+"\n"
+"- Invited portal users and all internal users: all internal users can access the project and all of its tasks without distinction.\n"
+"When following a project, portal users will get access to all of its tasks without distinction. Otherwise, they will only get access to the specific tasks they are following."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_phone
+msgid "Phone"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_form2
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_pivot
+msgid "Planned"
+msgstr "Planificado"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__access_url
+msgid "Portal Access URL"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__priority
+msgid "Priority"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__progress
+msgid "Progress"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model,name:project_task_followers_mgmt_timesheet.model_project_project
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_account_analytic_line__project_id
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__project_id
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Project"
+msgstr "Proyecto"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__manager_id
+msgid "Project Manager"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__project_privacy_visibility
+msgid "Project Visibility"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_project_id
+msgid ""
+"Project in which sub-tasks of the current project will be created. It can be"
+" the current project itself."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_ids
+msgid "Rating"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_avg
+msgid "Rating Average"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_last_feedback
+msgid "Rating Last Feedback"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_last_image
+msgid "Rating Last Image"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_last_value
+msgid "Rating Last Value"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_count
+msgid "Rating count"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_last_feedback
+msgid "Reason of the rating"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__recurrence_id
+msgid "Recurrence"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__recurrence_update
+msgid "Recurrence Update"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__recurring_task
+msgid "Recurrent"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__allow_recurring_tasks
+msgid "Recurring Tasks"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__remaining_hours
+msgid "Remaining Hours"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_day
+msgid "Repeat Day"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_interval
+msgid "Repeat Every"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_month
+msgid "Repeat Month"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_on_month
+msgid "Repeat On Month"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_on_year
+msgid "Repeat On Year"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_show_day
+msgid "Repeat Show Day"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_show_dow
+msgid "Repeat Show Dow"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_show_month
+msgid "Repeat Show Month"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_show_week
+msgid "Repeat Show Week"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_unit
+msgid "Repeat Unit"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_week
+msgid "Repeat Week"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_number
+msgid "Repetitions"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_user_id
+msgid "Responsible User"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__ribbon_message
+msgid "Ribbon message"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__sat
+msgid "Sat"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__access_token
+msgid "Security Token"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__stage_id
+msgid "Stage"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_project_id
+msgid "Sub-task Project"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_count
+msgid "Sub-task count"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__child_ids
+msgid "Sub-tasks"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_effective_hours
+msgid "Sub-tasks Hours Spent"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_planned_hours
+msgid "Sub-tasks Planned Hours"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_planned_hours
+msgid ""
+"Sum of the time planned of all the sub-tasks linked to this task. Usually "
+"less or equal to the initially time planned of this task."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__sun
+msgid "Sun"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__tag_ids
+msgid "Tags"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model,name:project_task_followers_mgmt_timesheet.model_project_task
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__task_id
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Task"
+msgstr "Tarea"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.actions.act_window,name:project_task_followers_mgmt_timesheet.action_view_task_timesheet_summary
+#: model:ir.ui.menu,name:project_task_followers_mgmt_timesheet.menu_project_task_followers_mgmt_timesheet_report
+msgid "Task Analysis - Allowed users"
+msgstr "Análisis de tareas por usuario asignado"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model,name:project_task_followers_mgmt_timesheet.model_project_task_timesheet_summary
+msgid "Task Timesheet Summaries"
+msgstr "Resúmenes de partes de horas de la tarea"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__task_active
+msgid "Task active"
+msgstr "Tarea activa"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_pivot
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Tasks Analysis - Allowed users"
+msgstr "Análisis de tarea por usuario asignado"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__recurring_count
+msgid "Tasks in Recurrence"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__is_closed
+msgid "Tasks in this stage are considered as closed."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__email_from
+msgid "These people will receive email."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__thu
+msgid "Thu"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__planned_hours
+msgid "Time planned to achieve this task (including its sub-tasks)."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_effective_hours
+msgid "Time spent on the sub-tasks (and their own sub-tasks) of this task."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__effective_hours
+msgid "Time spent on this task, excluding its sub-tasks."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__total_hours_spent
+msgid "Time spent on this task, including its sub-tasks."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task__timesheet_summary_ids
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_interval__timesheet_summary_ids
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__timesheet_summary_ids
+msgid "Timesheet Summaries"
+msgstr "Resumen de partes de horas"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_form2
+msgid "Timesheet summaries"
+msgstr "Resumen de partes de horas"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__timesheet_ids
+msgid "Timesheets"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__allow_timesheets
+msgid "Timesheets can be logged on this task."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__name
+msgid "Title"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__total_hours_spent
+msgid "Total Hours"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__remaining_hours
+msgid ""
+"Total remaining time, can be re-estimated periodically by the assignee of "
+"the task."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__tue
+msgid "Tue"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_unread
+msgid "Unread Messages"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_unread_counter
+msgid "Unread Messages Counter"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_type
+msgid "Until"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__allowed_user_id
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "User"
+msgstr "Usuario"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__user_email
+msgid "User Email"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__allowed_user_ids
+msgid "Visible to"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__website_message_ids
+msgid "Website Messages"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__website_message_ids
+msgid "Website communication history"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__wed
+msgid "Wed"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__working_days_open
+msgid "Working days to assign"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__working_days_close
+msgid "Working days to close"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__working_hours_open
+msgid "Working hours to assign"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__working_hours_close
+msgid "Working hours to close"
+msgstr ""

--- a/project_task_followers_mgmt_timesheet/i18n/project_task_followers_mgmt_timesheet.pot
+++ b/project_task_followers_mgmt_timesheet/i18n/project_task_followers_mgmt_timesheet.pot
@@ -1,0 +1,990 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* project_task_followers_mgmt_timesheet
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-04-14 11:19+0000\n"
+"PO-Revision-Date: 2023-04-14 11:19+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_type
+msgid ""
+"\n"
+"        Indicates task type according to associated partner:\n"
+"        internal - belongs to an internal project (has no partner)\n"
+"        customer - the project was linked to a partner\n"
+"        "
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_type_color_id
+msgid ""
+"\n"
+"        Technical field that help us to set a different color for tasks\n"
+"        depending on their partner_type.\n"
+"        "
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__access_warning
+msgid "Access warning"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__active
+msgid "Active"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__analytic_account_active
+msgid "Active Analytic Account"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Active Tasks"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_ids
+msgid "Activities"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_state
+msgid "Activity State"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__allow_subtasks
+msgid "Allow Sub-tasks"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__allow_timesheets
+msgid "Allow timesheets"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model,name:project_task_followers_mgmt_timesheet.model_account_analytic_line
+msgid "Analytic Line"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__user_id
+msgid "Assigned to"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__date_assign
+msgid "Assigning Date"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__attachment_ids
+msgid "Attachment that don't come from message."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_is_company
+msgid "Check if the contact is a company, otherwise it is a person"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_city
+msgid "City"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__is_closed
+msgid "Closing Stage"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__color
+msgid "Color Index"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__commercial_partner_id
+msgid "Commercial Entity"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__company_id
+msgid "Company"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__displayed_image_id
+msgid "Cover Image"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_id
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Customer"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__access_url
+msgid "Customer Portal URL"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Customer Tasks"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_weekday
+msgid "Day Of The Week"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__date_deadline
+msgid "Deadline"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__description
+msgid "Description"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_form2
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_pivot
+msgid "Deviation"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_account_analytic_line__display_name
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_project__display_name
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task__display_name
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__progress
+msgid "Display progress of current task."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_form2
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_pivot
+msgid "Done"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_email
+msgid "Email"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__email_from
+msgid "Email From"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__email_cc
+msgid "Email cc"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__encode_uom_in_days
+msgid "Encode Uom In Days"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_until
+msgid "End Date"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__date_end
+msgid "Ending Date"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_channel_ids
+msgid "Followers (Channels)"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__fri
+msgid "Fri"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__sequence
+msgid "Gives the sequence order when displaying a list of tasks."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Group By"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__hours_deviation
+msgid "Hours Deviation"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__hours_effective
+msgid "Hours Effective"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__hours_planned
+msgid "Hours Planned"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__effective_hours
+msgid "Hours Spent"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_account_analytic_line__id
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_project__id
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task__id
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__id
+msgid "ID"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_exception_icon
+msgid "Icon"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_needaction
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_unread
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_has_error
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Inactive Tasks"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__planned_hours
+msgid "Initially Planned Hours"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Internal Tasks"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__task_interval_count
+msgid "Interval count"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__task_interval_ids
+msgid "Intervals"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_is_company
+msgid "Is a Company"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__legend_blocked
+msgid "Kanban Blocked Explanation"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__legend_normal
+msgid "Kanban Ongoing Explanation"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__kanban_state
+msgid "Kanban State"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__kanban_state_label
+msgid "Kanban State Label"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__legend_done
+msgid "Kanban Valid Explanation"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_account_analytic_line____last_update
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_project____last_update
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task____last_update
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__date_last_stage_update
+msgid "Last Stage Update"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__email_cc
+msgid "List of cc from incoming emails."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_main_attachment_id
+msgid "Main Attachment"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__attachment_ids
+msgid "Main Attachments"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__mon
+msgid "Mon"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_summary
+msgid "Next Activity Summary"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_type_id
+msgid "Next Activity Type"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__recurrence_message
+msgid "Next Recurrencies"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_needaction_counter
+msgid "Number of messages which requires an action"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_unread_counter
+msgid "Number of unread messages"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__legend_blocked
+msgid ""
+"Override the default value displayed for the blocked state for kanban "
+"selection, when the task or issue is in that stage."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__legend_done
+msgid ""
+"Override the default value displayed for the done state for kanban "
+"selection, when the task or issue is in that stage."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__legend_normal
+msgid ""
+"Override the default value displayed for the normal state for kanban "
+"selection, when the task or issue is in that stage."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__overtime
+msgid "Overtime"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__parent_id
+msgid "Parent Task"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_type
+msgid "Partner Type"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_type_color_id
+msgid "Partner Type Color"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__project_privacy_visibility
+msgid ""
+"People to whom this project and its tasks will be visible.\n"
+"\n"
+"- Invited internal users: when following a project, internal users will get access to all of its tasks without distinction. Otherwise, they will only get access to the specific tasks they are following.\n"
+" A user with the project > administrator access right level can still access this project and its tasks, even if they are not explicitly part of the followers.\n"
+"\n"
+"- All internal users: all internal users can access the project and all of its tasks without distinction.\n"
+"\n"
+"- Invited portal users and all internal users: all internal users can access the project and all of its tasks without distinction.\n"
+"When following a project, portal users will get access to all of its tasks without distinction. Otherwise, they will only get access to the specific tasks they are following."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__partner_phone
+msgid "Phone"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_form2
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_pivot
+msgid "Planned"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__access_url
+msgid "Portal Access URL"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__priority
+msgid "Priority"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__progress
+msgid "Progress"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model,name:project_task_followers_mgmt_timesheet.model_project_project
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_account_analytic_line__project_id
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__project_id
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Project"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__manager_id
+msgid "Project Manager"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__project_privacy_visibility
+msgid "Project Visibility"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_project_id
+msgid ""
+"Project in which sub-tasks of the current project will be created. It can be"
+" the current project itself."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_ids
+msgid "Rating"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_avg
+msgid "Rating Average"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_last_feedback
+msgid "Rating Last Feedback"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_last_image
+msgid "Rating Last Image"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_last_value
+msgid "Rating Last Value"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_count
+msgid "Rating count"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__rating_last_feedback
+msgid "Reason of the rating"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__recurrence_id
+msgid "Recurrence"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__recurrence_update
+msgid "Recurrence Update"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__recurring_task
+msgid "Recurrent"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__allow_recurring_tasks
+msgid "Recurring Tasks"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__remaining_hours
+msgid "Remaining Hours"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_day
+msgid "Repeat Day"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_interval
+msgid "Repeat Every"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_month
+msgid "Repeat Month"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_on_month
+msgid "Repeat On Month"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_on_year
+msgid "Repeat On Year"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_show_day
+msgid "Repeat Show Day"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_show_dow
+msgid "Repeat Show Dow"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_show_month
+msgid "Repeat Show Month"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_show_week
+msgid "Repeat Show Week"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_unit
+msgid "Repeat Unit"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_week
+msgid "Repeat Week"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_number
+msgid "Repetitions"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_user_id
+msgid "Responsible User"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__ribbon_message
+msgid "Ribbon message"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__sat
+msgid "Sat"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__access_token
+msgid "Security Token"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__stage_id
+msgid "Stage"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_project_id
+msgid "Sub-task Project"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_count
+msgid "Sub-task count"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__child_ids
+msgid "Sub-tasks"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_effective_hours
+msgid "Sub-tasks Hours Spent"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_planned_hours
+msgid "Sub-tasks Planned Hours"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_planned_hours
+msgid ""
+"Sum of the time planned of all the sub-tasks linked to this task. Usually "
+"less or equal to the initially time planned of this task."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__sun
+msgid "Sun"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__tag_ids
+msgid "Tags"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model,name:project_task_followers_mgmt_timesheet.model_project_task
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__task_id
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Task"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.actions.act_window,name:project_task_followers_mgmt_timesheet.action_view_task_timesheet_summary
+#: model:ir.ui.menu,name:project_task_followers_mgmt_timesheet.menu_project_task_followers_mgmt_timesheet_report
+msgid "Task Analysis - Allowed users"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model,name:project_task_followers_mgmt_timesheet.model_project_task_timesheet_summary
+msgid "Task Timesheet Summaries"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__task_active
+msgid "Task active"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_pivot
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "Tasks Analysis - Allowed users"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__recurring_count
+msgid "Tasks in Recurrence"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__is_closed
+msgid "Tasks in this stage are considered as closed."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__email_from
+msgid "These people will receive email."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__thu
+msgid "Thu"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__planned_hours
+msgid "Time planned to achieve this task (including its sub-tasks)."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__subtask_effective_hours
+msgid "Time spent on the sub-tasks (and their own sub-tasks) of this task."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__effective_hours
+msgid "Time spent on this task, excluding its sub-tasks."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__total_hours_spent
+msgid "Time spent on this task, including its sub-tasks."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task__timesheet_summary_ids
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_interval__timesheet_summary_ids
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__timesheet_summary_ids
+msgid "Timesheet Summaries"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_form2
+msgid "Timesheet summaries"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__timesheet_ids
+msgid "Timesheets"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__allow_timesheets
+msgid "Timesheets can be logged on this task."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__name
+msgid "Title"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__total_hours_spent
+msgid "Total Hours"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__remaining_hours
+msgid ""
+"Total remaining time, can be re-estimated periodically by the assignee of "
+"the task."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__tue
+msgid "Tue"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_unread
+msgid "Unread Messages"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__message_unread_counter
+msgid "Unread Messages Counter"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__repeat_type
+msgid "Until"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__allowed_user_id
+#: model_terms:ir.ui.view,arch_db:project_task_followers_mgmt_timesheet.view_task_timesheet_summary_search
+msgid "User"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__user_email
+msgid "User Email"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__allowed_user_ids
+msgid "Visible to"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__website_message_ids
+msgid "Website Messages"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,help:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__website_message_ids
+msgid "Website communication history"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__wed
+msgid "Wed"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__working_days_open
+msgid "Working days to assign"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__working_days_close
+msgid "Working days to close"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__working_hours_open
+msgid "Working hours to assign"
+msgstr ""
+
+#. module: project_task_followers_mgmt_timesheet
+#: model:ir.model.fields,field_description:project_task_followers_mgmt_timesheet.field_project_task_timesheet_summary__working_hours_close
+msgid "Working hours to close"
+msgstr ""

--- a/project_task_followers_mgmt_timesheet/migrations/14.0.2.0.0/post-migration.py
+++ b/project_task_followers_mgmt_timesheet/migrations/14.0.2.0.0/post-migration.py
@@ -1,0 +1,13 @@
+# © 2023 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """
+    Initial timesheet summaries creation for every project
+    """
+    env["project.project"].with_context(active_test=False).search([
+        ("privacy_visibility", "=", "followers"),
+    ]).task_ids._timesheet_summary_process()

--- a/project_task_followers_mgmt_timesheet/models/__init__.py
+++ b/project_task_followers_mgmt_timesheet/models/__init__.py
@@ -1,1 +1,4 @@
 from . import hr_timesheet
+from . import project_task
+from . import project_task_timesheet_summary
+from . import project_project

--- a/project_task_followers_mgmt_timesheet/models/project_project.py
+++ b/project_task_followers_mgmt_timesheet/models/project_project.py
@@ -1,0 +1,14 @@
+# © 2023 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+from odoo import models
+
+
+class ProjectProject(models.Model):
+    _inherit = "project.project"
+
+    def write(self, values):
+        res = super().write(values)
+        if "privacy_visibility" in values.keys():
+            self.task_ids._timesheet_summary_process()
+        return res

--- a/project_task_followers_mgmt_timesheet/models/project_task.py
+++ b/project_task_followers_mgmt_timesheet/models/project_task.py
@@ -1,0 +1,54 @@
+# © 2023 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+from odoo import api, fields, models
+
+
+class ProjectTask(models.Model):
+    _inherit = "project.task"
+
+    timesheet_summary_ids = fields.One2many(
+        comodel_name="project.task.timesheet_summary",
+        inverse_name="task_id",
+        string="Timesheet Summaries",
+    )
+
+    @api.model
+    def create(self, values):
+        res = super().create(values)
+        res._timesheet_summary_process()
+        return res
+
+    def write(self, values):
+        res = super().write(values)
+        fields_change = ["planned_hours", "allowed_user_ids"]
+        values_keys = values.keys()
+        if any(field in values_keys for field in fields_change):
+            self._timesheet_summary_process()
+        return res
+
+    def _timesheet_summary_process(self):
+        """
+        (Re)create timesheet summaries for the tasks
+        """
+        self_sudo = self.sudo()
+        follower_tasks = self_sudo.filtered(
+            lambda x: x.project_id.privacy_visibility == "followers"
+        )
+        for task in follower_tasks:
+            users_summary = task.timesheet_summary_ids.mapped("allowed_user_id")
+            new_users = (task.allowed_user_ids - users_summary)
+            if new_users:
+                task.timesheet_summary_ids = [
+                    (0, 0, {"allowed_user_id": new_user.id}) for new_user in new_users
+                ]
+            delete_users = (users_summary - task.allowed_user_ids)
+            task.timesheet_summary_ids.filtered(
+                lambda x: x.allowed_user_id.id in delete_users.ids
+            ).unlink()
+            if task.timesheet_summary_ids:
+                task.timesheet_summary_ids.write({
+                    "hours_planned": task.planned_hours / len(task.allowed_user_ids)
+                })
+        # Non-followers projects has no summary data
+        (self_sudo - follower_tasks).timesheet_summary_ids.unlink()

--- a/project_task_followers_mgmt_timesheet/models/project_task_timesheet_summary.py
+++ b/project_task_followers_mgmt_timesheet/models/project_task_timesheet_summary.py
@@ -1,0 +1,56 @@
+# © 2023 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+from odoo import api, fields, models
+
+
+class ProjectTaskTimesheetSummary(models.Model):
+    _name = "project.task.timesheet_summary"
+    _description = "Task Timesheet Summaries"
+    _inherits = {"project.task": "task_id"}
+
+    task_id = fields.Many2one(
+        comodel_name="project.task",
+        string="Task",
+        auto_join=True,
+        index=True,
+        ondelete="cascade",
+        required=True,
+    )
+    active = fields.Boolean(default=True)
+    task_active = fields.Boolean(
+        related="task_id.active",
+        store=True,
+        string="Task active",
+    )
+
+    allowed_user_id = fields.Many2one(
+        comodel_name="res.users",
+        required=True,
+        string="User",
+    )
+    hours_planned = fields.Float()
+    hours_effective = fields.Float(
+        compute="_compute_hours_effective",
+        store=True,
+    )
+    hours_deviation = fields.Float(
+        compute="_compute_hours_deviation",
+        store=True,
+    )
+
+    @api.depends("timesheet_ids.unit_amount", "allowed_user_id")
+    def _compute_hours_effective(self):
+        for summary in self:
+            summary.hours_effective = sum(
+                summary.timesheet_ids.filtered(
+                    lambda x: x.user_id == summary.allowed_user_id
+                ).mapped("unit_amount")
+            )
+
+    @api.depends("hours_planned", "hours_effective")
+    def _compute_hours_deviation(self):
+        for summary in self:
+            summary.hours_deviation = (
+                summary.hours_planned - summary.hours_effective
+            )

--- a/project_task_followers_mgmt_timesheet/readme/DESCRIPTION.rst
+++ b/project_task_followers_mgmt_timesheet/readme/DESCRIPTION.rst
@@ -1,3 +1,7 @@
 Timesheet extension for ``project_task_followers_mgmt`` addon, that enables
 selecting a proyect in timesheets that matches this addon requirements (accessing
 followers project it user is allowed in at least one task).
+
+Also adds a task analysis report based on task allowed users and their timesheets.
+Each allowed user will have as task planned hours a proportional part depending
+on the count of allowed users.

--- a/project_task_followers_mgmt_timesheet/security/ir.model.access.csv
+++ b/project_task_followers_mgmt_timesheet/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_project_task_timesheet_summary,access_project_task_timesheet_summary,model_project_task_timesheet_summary,project.group_project_manager,1,0,0,0

--- a/project_task_followers_mgmt_timesheet/static/description/index.html
+++ b/project_task_followers_mgmt_timesheet/static/description/index.html
@@ -371,6 +371,9 @@ ul.auto-toc {
 <p>Timesheet extension for <tt class="docutils literal">project_task_followers_mgmt</tt> addon, that enables
 selecting a proyect in timesheets that matches this addon requirements (accessing
 followers project it user is allowed in at least one task).</p>
+<p>Also adds a task analysis report based on task allowed users and their timesheets.
+Each allowed user will have as task planned hours a proportional part depending
+on the count of allowed users.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/project_task_followers_mgmt_timesheet/views/project_task_timesheet_summary_views.xml
+++ b/project_task_followers_mgmt_timesheet/views/project_task_timesheet_summary_views.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_task_timesheet_summary_pivot" model="ir.ui.view">
+        <field name="name">project.task.timesheet_summary.pivot</field>
+        <field name="model">project.task.timesheet_summary</field>
+        <field name="arch" type="xml">
+            <pivot
+                string="Tasks Analysis - Allowed users"
+                display_quantity="False"
+                disable_linking="True"
+                sample="1"
+            >
+                <field name="allowed_user_id" type="row"/>
+                <field name="hours_planned" type="measure" string="Planned"/>
+                <field name="hours_effective" type="measure" string="Done"/>
+                <field name="hours_deviation" type="measure" string="Deviation"/>
+            </pivot>
+        </field>
+    </record>
+    <record id="view_task_timesheet_summary_tree" model="ir.ui.view">
+        <field name="name">project.task.timesheet_summary.tree</field>
+        <field name="model">project.task.timesheet_summary</field>
+        <field name="arch" type="xml">
+            <tree decoration-danger="hours_deviation &lt; 0">
+                <field name="allowed_user_id" widget="many2one_avatar_user"/>
+                <field name="project_id"/>
+                <field name="task_id"/>
+                <field name="hours_planned" widget="timesheet_uom"/>
+                <field name="hours_effective" widget="timesheet_uom"/>
+                <field name="hours_deviation" widget="timesheet_uom"/>
+            </tree>
+        </field>
+    </record>
+    <record id="view_task_timesheet_summary_search" model="ir.ui.view">
+        <field name="name">project.task.timesheet_summary.search</field>
+        <field name="model">project.task.timesheet_summary</field>
+        <field name="arch" type="xml">
+            <search string="Tasks Analysis - Allowed users">
+                <field name="allowed_user_id"/>
+                <field name="project_id"/>
+                <field name="task_id"/>
+                <separator/>
+                <filter
+                    name="filter_active_tasks"
+                    string="Active Tasks"
+                    domain="[('task_active','=',True)]"
+                />
+                <filter
+                    name="filter_inactive_tasks"
+                    string="Inactive Tasks"
+                    domain="[('task_active','=',False)]"
+                />
+                <separator/>
+                <filter
+                    name="filter_customer_tasks"
+                    string="Customer Tasks"
+                    domain="[('partner_id','!=',False)]"
+                />
+                <filter
+                    name="filter_internal_tasks"
+                    string="Internal Tasks"
+                    domain="[('partner_id','=',False)]"
+                />
+                <group expand="0" string="Group By">
+                    <filter string="User" name="groupby_user" context="{'group_by': 'allowed_user_id'}"/>
+                    <filter string="Customer" name="groupby_partner" context="{'group_by': 'partner_id'}"/>
+                    <filter string="Project" name="groupby_project" context="{'group_by': 'project_id'}"/>
+                    <filter string="Task" name="groupby_task" context="{'group_by': 'task_id'}"/>
+                </group>                
+            </search>
+        </field>
+    </record>
+
+    <record id="action_view_task_timesheet_summary" model="ir.actions.act_window">
+        <field name="name">Task Analysis - Allowed users</field>
+        <field name="res_model">project.task.timesheet_summary</field>
+        <field name="view_mode">pivot,tree</field>
+        <field
+            name="view_ids"
+            eval="[
+                (5, 0, 0),
+                (0, 0, {'view_mode': 'pivot', 'view_id': ref('view_task_timesheet_summary_pivot')}),
+                (0, 0, {'view_mode': 'tree', 'view_id': ref('view_task_timesheet_summary_tree')}),
+            ]"
+        />
+        <field name="context">{
+            'search_default_filter_active_tasks': 1,
+            'search_default_groupby_user': 1,
+        }</field>
+    </record>
+    <menuitem id="menu_project_task_followers_mgmt_timesheet_report"
+        name="Task Analysis - Allowed users"
+        action="project_task_followers_mgmt_timesheet.action_view_task_timesheet_summary"
+        parent="project.menu_project_report"
+        sequence="30"
+    />
+</odoo>

--- a/project_task_followers_mgmt_timesheet/views/project_task_views.xml
+++ b/project_task_followers_mgmt_timesheet/views/project_task_views.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_task_form2" model="ir.ui.view">
+        <field name="name">
+            project.task.form.inherited (in project_task_followers_mgmt_timesheet)
+        </field>
+        <field name="model">project.task</field>
+        <field
+            name="inherit_id"
+            ref="hr_timesheet.view_task_form2_inherited" 
+        />
+        <field
+            name="groups_id"
+            eval="[(4, ref('project.group_project_manager'))]"
+        />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//page[@id='timesheets_tab']"
+                position="before"
+            >
+                <page
+                    string="Timesheet summaries"
+                    attrs="{'invisible': ['|',('allow_timesheets','=',False),('project_privacy_visibility','!=','followers')]}"
+                >
+                    <field
+                        name="timesheet_summary_ids"
+                        nolabel="1"
+                    >
+                        <!-- TODO prevent form open when clicking. Workaround creating a simple one -->
+                        <form>
+                            <group>
+                                <group>
+                                    <field name="allowed_user_id"/>
+                                </group>
+                                <group>
+                                    <field
+                                        name="hours_planned"
+                                        widget="timesheet_uom_no_toggle"
+                                        string="Planned"
+                                    />
+                                    <field
+                                        name="hours_effective"
+                                        widget="timesheet_uom_no_toggle"
+                                        string="Done"
+                                    />
+                                    <field
+                                        name="hours_deviation"
+                                        widget="timesheet_uom_no_toggle"
+                                        string="Deviation"
+                                    />
+                                </group>
+                            </group>
+                        </form>
+                        <tree decoration-danger="hours_deviation &lt; 0">
+                            <field name="allowed_user_id"/>
+                            <field
+                                name="hours_planned"
+                                widget="timesheet_uom_no_toggle"
+                                string="Planned"
+                            />
+                            <field
+                                name="hours_effective"
+                                widget="timesheet_uom_no_toggle"
+                                string="Done"
+                            />
+                            <field
+                                name="hours_deviation"
+                                widget="timesheet_uom_no_toggle"
+                                string="Deviation"
+                            />
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This commit adds a task analysis report taking in account that in followers mode, more than a user is assigned to the task, then planned and effective hours made in timesheets should be distributed between these users.

This is achieved maintaning a "Timesheet summaries" structure that is later used in reporting.