### PR TITLE
[14.0][FIX] project_task_followers_mgmt_timesheet: prevent timesheet summary access error

### DIFF
--- a/project_task_followers_mgmt_timesheet/__manifest__.py
+++ b/project_task_followers_mgmt_timesheet/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "14.0.3.0.0",
+    "version": "14.0.3.0.1",
     "category": "Project",
     "website": "https://github.com/solvosci/slv-project",
     "depends": ["project_task_followers_mgmt", "hr_timesheet"],

--- a/project_task_followers_mgmt_timesheet/security/ir.model.access.csv
+++ b/project_task_followers_mgmt_timesheet/security/ir.model.access.csv
@@ -1,2 +1,2 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_project_task_timesheet_summary,access_project_task_timesheet_summary,model_project_task_timesheet_summary,project.group_project_manager,1,0,0,0
+access_project_task_timesheet_summary,access_project_task_timesheet_summary,model_project_task_timesheet_summary,base.group_user,1,0,0,0


### PR DESCRIPTION
When accessing e.g. to OCA's Timesheet Sheets, an initial read to Timesheet Summary is made for every user, raising an error for non-project managers.

With this fix read access is enabled for everyone. Since current frontend access to Timesheet Summary in task form and Task Analysis menu is actually restricted to Project Managers, no security leak is generated.